### PR TITLE
OUS support

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const vars = {
     dexcomBaseUrl: "https://share2.dexcom.com/ShareWebServices/Services",
     dexcomBaseUrlOus: "https://shareous1.dexcom.com/ShareWebServices/Services",
     // Endpoints:
-    dexcomLoginEndpoint: "/General/LoginPublisherAccountByName",
+    dexcomLoginEndpoint: "/General/LoginPublisherAccountById",
     dexcomAuthenticateEndpoint: "/General/AuthenticatePublisherAccount",
     dexcomVerifySerialNumberEndpoint:
         "/Publisher/CheckMonitoredReceiverAssignmentStatus",
@@ -132,9 +132,13 @@ class Dexcom {
         }
 
         try {
-            let data = await this._request(vars.dexcomAuthenticateEndpoint, 'post', postData)
-            data = await this._request(vars.dexcomLoginEndpoint, 'post', postData)
-            this.sessionId = data
+            let accountId = await this._request(vars.dexcomAuthenticateEndpoint, 'post', postData);
+            let sessionId = await this._request(vars.dexcomLoginEndpoint, 'post', {
+                accountId,
+                password: this.password,
+                applicationId: vars.dexcomApplicationId
+            });
+            this.sessionId = sessionId;
             return
         } catch (e) {
             console.error(e)

--- a/index.js
+++ b/index.js
@@ -98,7 +98,7 @@ class Dexcom {
         this.ous = ous;
         this.sessionId = null;
 
-        this._baseUrl = ous ? vars.dexcomOusBaseUrl : vars.dexcomBaseUrl;
+        this._baseUrl = ous ? vars.dexcomBaseUrlOus : vars.dexcomBaseUrl;
         this._baseHeaders = {
             'Content-Type': 'application/json',
             'Accept': 'application/json',


### PR DESCRIPTION
Hello and thank you for publishing this library.

This PR makes two changes:

1. Fixes a misnamed reference to `vars.dexcomBaseUrlOus`
2. Uses the newer `LoginPublisherAccountById` endpoint to fetch a session ID. See also https://github.com/gagebenne/pydexcom/commit/01c2a763938b57b6bfab964593ee082059ae9bf8 for reference.

I've verified this introduces support for outside-US users, and doesn't break anything for US users.