### PR TITLE
Properly handling faulty logins

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ const Client = (function () {
                 throw new Error("Error creating session")
             }
 
-            if (this.sessionId == DEFAULT_SESSION_ID)
+            if (this.sessionId == DEFAULT_SESSION_ID || typeof this.sessionId !== "string")
                 throw new Error("Invalid session")
         }
 


### PR DESCRIPTION
Invalid logins are not really caught unless the type of the session is is verified to be also a string in the first place